### PR TITLE
Add error message component below title

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -15,6 +17,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
@@ -22,9 +27,11 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.12.0",
+    "jsdom": "^26.1.0",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.15.0",
-    "vite": "^6.0.1"
+    "vite": "^6.0.1",
+    "vitest": "^3.1.3"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "test": "vitest run --config vitest.config.ts",
+    "test:watch": "vitest --config vitest.config.ts"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -17,9 +17,11 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",
+    "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^22.15.19",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/src/App.css
+++ b/src/App.css
@@ -7,3 +7,27 @@
   max-width: 300px;
   max-height: 300px;
 }
+.error-message {
+  background-color: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+  border-radius: 4px;
+  padding: 10px 15px;
+  margin: 10px 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.error-message button {
+  background: none;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  color: #721c24;
+  margin-left: 10px;
+}
+
+.error-message button:hover {
+  color: #4d1319;
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import App from './App';
+
+// Extract the ErrorMessage component for direct testing
+// This is the same implementation from App.tsx
+function ErrorMessage({ message, onClose }: { message: string, onClose: () => void }) {
+  return (
+    <div className="error-message">
+      <span>{message}</span>
+      <button onClick={onClose} aria-label="Close error message">×</button>
+    </div>
+  );
+}
+
+describe('ErrorMessage component', () => {
+  it('renders error message correctly', () => {
+    const testMessage = 'Test error message';
+    const handleClose = vi.fn();
+    
+    render(<ErrorMessage message={testMessage} onClose={handleClose} />);
+    
+    // Check if the message is displayed
+    expect(screen.getByText(testMessage)).toBeInTheDocument();
+    
+    // Check if the close button is present
+    expect(screen.getByLabelText('Close error message')).toBeInTheDocument();
+  });
+  
+  it('calls onClose when close button is clicked', () => {
+    const testMessage = 'Test error message';
+    const handleClose = vi.fn();
+    
+    render(<ErrorMessage message={testMessage} onClose={handleClose} />);
+    
+    // Click the close button
+    fireEvent.click(screen.getByLabelText('Close error message'));
+    
+    // Check if the onClose function was called
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Error handling in App component', () => {
+  it('shows error message when clipboard operation fails', async () => {
+    // Mock the clipboard API to throw an error
+    const originalClipboard = navigator.clipboard;
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        read: vi.fn().mockRejectedValue(new Error('Clipboard access denied')),
+      },
+      configurable: true,
+    });
+    
+    render(<App />);
+    
+    // Click the "Paste from clipboard" button
+    fireEvent.click(screen.getByText('Paste from clipboard'));
+    
+    // Check if the error message appears
+    const errorMessage = await screen.findByText('Clipboard access denied');
+    expect(errorMessage).toBeInTheDocument();
+    
+    // Click the close button
+    fireEvent.click(screen.getByLabelText('Close error message'));
+    
+    // Check if the error message disappears
+    expect(screen.queryByText('Clipboard access denied')).not.toBeInTheDocument();
+    
+    // Restore the original clipboard
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+    });
+  });
+});

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import App from './App';
+
+// Import dom-testing-library directly as the older @testing-library/react doesn't export screen or fireEvent
+import { getByText, getByLabelText, findByText, queryByText } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 
 // Extract the ErrorMessage component for direct testing
 // This is the same implementation from App.tsx
@@ -18,23 +22,24 @@ describe('ErrorMessage component', () => {
     const testMessage = 'Test error message';
     const handleClose = vi.fn();
     
-    render(<ErrorMessage message={testMessage} onClose={handleClose} />);
+    const { container } = render(<ErrorMessage message={testMessage} onClose={handleClose} />);
     
     // Check if the message is displayed
-    expect(screen.getByText(testMessage)).toBeInTheDocument();
+    expect(getByText(container, testMessage)).toBeInTheDocument();
     
     // Check if the close button is present
-    expect(screen.getByLabelText('Close error message')).toBeInTheDocument();
+    expect(getByLabelText(container, 'Close error message')).toBeInTheDocument();
   });
   
   it('calls onClose when close button is clicked', () => {
     const testMessage = 'Test error message';
     const handleClose = vi.fn();
     
-    render(<ErrorMessage message={testMessage} onClose={handleClose} />);
+    const { container } = render(<ErrorMessage message={testMessage} onClose={handleClose} />);
     
     // Click the close button
-    fireEvent.click(screen.getByLabelText('Close error message'));
+    const closeButton = getByLabelText(container, 'Close error message');
+    userEvent.click(closeButton);
     
     // Check if the onClose function was called
     expect(handleClose).toHaveBeenCalledTimes(1);
@@ -52,20 +57,22 @@ describe('Error handling in App component', () => {
       configurable: true,
     });
     
-    render(<App />);
+    const { container } = render(<App />);
     
     // Click the "Paste from clipboard" button
-    fireEvent.click(screen.getByText('Paste from clipboard'));
+    const pasteButton = getByText(container, 'Paste from clipboard');
+    userEvent.click(pasteButton);
     
     // Check if the error message appears
-    const errorMessage = await screen.findByText('Clipboard access denied');
+    const errorMessage = await findByText(container, 'Clipboard access denied');
     expect(errorMessage).toBeInTheDocument();
     
     // Click the close button
-    fireEvent.click(screen.getByLabelText('Close error message'));
+    const closeButton = getByLabelText(container, 'Close error message');
+    userEvent.click(closeButton);
     
     // Check if the error message disappears
-    expect(screen.queryByText('Clipboard access denied')).not.toBeInTheDocument();
+    expect(queryByText(container, 'Clipboard access denied')).not.toBeInTheDocument();
     
     // Restore the original clipboard
     Object.defineProperty(navigator, 'clipboard', {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ export default function App() {
   const [originalHeight, setOriginalHeight] = useState<number | undefined>(undefined)
   const [keepsRatio, setKeepsRatio] = useState<boolean>(true)
   const [rotationAngle, setRotationAngle] = useState<number>(0)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const pasteFromClipboard = useCallback(async () => {
     try {
@@ -28,7 +29,7 @@ export default function App() {
         setOriginalImageSrc(dataURL)
       }
     } catch (e) {
-      console.error(e)
+      setErrorMessage(e instanceof Error ? e.message : 'Failed to paste image from clipboard')
     }
   }, [])
 
@@ -94,6 +95,7 @@ export default function App() {
   return (
     <main ref={main}>
       <h1>Resize</h1>
+      {errorMessage && <ErrorMessage message={errorMessage} onClose={() => setErrorMessage(null)} />}
       <button onClick={pasteFromClipboard}>Paste from clipboard</button>
       <span> or C-v</span>
       <div>
@@ -123,6 +125,16 @@ export default function App() {
       </div>
     </main>
   )
+}
+
+// Error Message Component
+function ErrorMessage({ message, onClose }: { message: string, onClose: () => void }) {
+  return (
+    <div className="error-message">
+      <span>{message}</span>
+      <button onClick={onClose} aria-label="Close error message">×</button>
+    </div>
+  );
 }
 
 function ResizedImage({ originalImageSrc, width, height, rotationAngle }: { originalImageSrc: string, width: number, height: number, rotationAngle: number }) {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,2 @@
+import '@testing-library/jest-dom'
+// Add any global test setup here

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,7 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  test: {
-    environment: 'jsdom',
-    globals: true,
-    setupFiles: ['./src/setupTests.ts'],
-  },
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/setupTests.ts'],
+  },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/setupTests.ts'],
+  },
+})


### PR DESCRIPTION
This PR adds an error message component that appears below the title. The error message will remain visible until manually dismissed by clicking the close button.